### PR TITLE
retry checks on errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dappnode/validator-tracker/internal/adapters/dappmanager"
 	"github.com/dappnode/validator-tracker/internal/adapters/notifier"
 	"github.com/dappnode/validator-tracker/internal/adapters/web3signer"
-	"github.com/dappnode/validator-tracker/internal/application/domain"
 	"github.com/dappnode/validator-tracker/internal/application/services"
 	"github.com/dappnode/validator-tracker/internal/config"
 	"github.com/dappnode/validator-tracker/internal/logger"
@@ -47,12 +46,11 @@ func main() {
 
 	// Start the duties checker service in a goroutine
 	dutiesChecker := &services.DutiesChecker{
-		Beacon:        beacon,
-		Signer:        web3Signer,
-		Notifier:      notifier,
-		Dappmanager:   dappmanager,
-		PollInterval:  1 * time.Minute,
-		CheckedEpochs: make(map[domain.ValidatorIndex]domain.Epoch),
+		Beacon:       beacon,
+		Signer:       web3Signer,
+		Notifier:     notifier,
+		Dappmanager:  dappmanager,
+		PollInterval: 1 * time.Minute,
 	}
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
- we always check if current justified epoch is different than last one
- if its different and beacon checks had any error, retry. if not, skip checks in this iteration
- we do not care if notifications had errors or not