### PR TITLE
add slashing notification only once x validator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dappnode/validator-tracker/internal/adapters/dappmanager"
 	"github.com/dappnode/validator-tracker/internal/adapters/notifier"
 	"github.com/dappnode/validator-tracker/internal/adapters/web3signer"
+	"github.com/dappnode/validator-tracker/internal/application/domain"
 	"github.com/dappnode/validator-tracker/internal/application/services"
 	"github.com/dappnode/validator-tracker/internal/config"
 	"github.com/dappnode/validator-tracker/internal/logger"
@@ -46,11 +47,12 @@ func main() {
 
 	// Start the duties checker service in a goroutine
 	dutiesChecker := &services.DutiesChecker{
-		Beacon:       beacon,
-		Signer:       web3Signer,
-		Notifier:     notifier,
-		Dappmanager:  dappmanager,
-		PollInterval: 1 * time.Minute,
+		Beacon:          beacon,
+		Signer:          web3Signer,
+		Notifier:        notifier,
+		Dappmanager:     dappmanager,
+		PollInterval:    1 * time.Minute,
+		SlashedNotified: make(map[domain.ValidatorIndex]bool),
 	}
 	wg.Add(1)
 	go func() {

--- a/internal/application/ports/beaconchain.go
+++ b/internal/application/ports/beaconchain.go
@@ -14,6 +14,7 @@ type BeaconChainAdapter interface {
 	GetCommitteeSizeMap(ctx context.Context, slot domain.Slot) (domain.CommitteeSizeMap, error)
 	GetBlockAttestations(ctx context.Context, slot domain.Slot) ([]domain.Attestation, error)
 	GetValidatorIndicesByPubkeys(ctx context.Context, pubkeys []string) ([]domain.ValidatorIndex, error)
+	GetSlashedValidators(ctx context.Context, indices []domain.ValidatorIndex) ([]domain.ValidatorIndex, error)
 
 	GetProposerDuties(ctx context.Context, epoch domain.Epoch, indices []domain.ValidatorIndex) ([]domain.ProposerDuty, error)
 	DidProposeBlock(ctx context.Context, slot domain.Slot) (bool, error)


### PR DESCRIPTION
- new map SlashedNotified in dutieschecker --> keeps track of validators slashed notified
- new method `GetSlashedValidators` in beacon adapter
- from finalized to justified state when searching validator indices